### PR TITLE
Add SEO metadata, sitemap, and robots.txt

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,37 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Inês Leite — Senior Data Scientist</title>
   <meta name="description" content="Senior Data Scientist specialising in causal inference, ML, and optimization. Based in Munich." />
+  <meta name="author" content="Inês Leite" />
+  <link rel="canonical" href="https://inesleite.github.io/" />
+
+  <meta property="og:type" content="website" />
+  <meta property="og:title" content="Inês Leite — Senior Data Scientist" />
+  <meta property="og:description" content="Senior Data Scientist specialising in causal inference, ML, and optimization. Based in Munich. Writing on geo experiments, MMM calibration, and measurement." />
+  <meta property="og:url" content="https://inesleite.github.io/" />
+  <meta property="og:site_name" content="Inês Leite" />
+
+  <meta name="twitter:card" content="summary" />
+  <meta name="twitter:title" content="Inês Leite — Senior Data Scientist" />
+  <meta name="twitter:description" content="Senior Data Scientist specialising in causal inference, ML, and optimization. Based in Munich." />
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    "name": "Inês Leite",
+    "url": "https://inesleite.github.io",
+    "jobTitle": "Senior Data Scientist",
+    "address": {
+      "@type": "PostalAddress",
+      "addressLocality": "Munich",
+      "addressCountry": "Germany"
+    },
+    "sameAs": [
+      "https://github.com/inesleite"
+    ]
+  }
+  </script>
+
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />

--- a/posts/calibrating-mmm-with-geo-experiments.html
+++ b/posts/calibrating-mmm-with-geo-experiments.html
@@ -4,6 +4,44 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Calibrating MMM with geo experiments — Inês Leite</title>
+  <meta name="description" content="How to use geo-experiment results as priors in MMM fitting: prior schemes, the loss-function view, and effects on the budget optimiser.">
+  <meta name="author" content="Inês Leite">
+  <link rel="canonical" href="https://inesleite.github.io/posts/calibrating-mmm-with-geo-experiments.html">
+
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Calibrating MMM with geo experiments">
+  <meta property="og:description" content="How to use geo-experiment results as priors in MMM fitting: prior schemes, the loss-function view, and effects on the budget optimiser.">
+  <meta property="og:url" content="https://inesleite.github.io/posts/calibrating-mmm-with-geo-experiments.html">
+  <meta property="og:site_name" content="Inês Leite">
+  <meta property="article:published_time" content="2026-01-15">
+  <meta property="article:author" content="Inês Leite">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Calibrating MMM with geo experiments">
+  <meta name="twitter:description" content="How to use geo-experiment results as priors in MMM fitting: prior schemes, the loss-function view, and effects on the budget optimiser.">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Calibrating MMM with geo experiments",
+    "description": "How to use geo-experiment results as priors in MMM fitting: prior schemes, the loss-function view, and effects on the budget optimiser.",
+    "datePublished": "2026-01-15",
+    "author": {
+      "@type": "Person",
+      "name": "Inês Leite",
+      "url": "https://inesleite.github.io"
+    },
+    "publisher": {
+      "@type": "Person",
+      "name": "Inês Leite"
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://inesleite.github.io/posts/calibrating-mmm-with-geo-experiments.html"
+    }
+  }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/posts/geo-holdouts-are-not-ab-tests.html
+++ b/posts/geo-holdouts-are-not-ab-tests.html
@@ -4,6 +4,44 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Geo holdouts are not A/B tests — Inês Leite</title>
+  <meta name="description" content="Why the A/B framework fails for geo experiments: SUTVA violations, spillover, parallel-trends as the design check, and honest power calculations.">
+  <meta name="author" content="Inês Leite">
+  <link rel="canonical" href="https://inesleite.github.io/posts/geo-holdouts-are-not-ab-tests.html">
+
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Geo holdouts are not A/B tests">
+  <meta property="og:description" content="Why the A/B framework fails for geo experiments: SUTVA violations, spillover, parallel-trends as the design check, and honest power calculations.">
+  <meta property="og:url" content="https://inesleite.github.io/posts/geo-holdouts-are-not-ab-tests.html">
+  <meta property="og:site_name" content="Inês Leite">
+  <meta property="article:published_time" content="2025-08-15">
+  <meta property="article:author" content="Inês Leite">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Geo holdouts are not A/B tests">
+  <meta name="twitter:description" content="Why the A/B framework fails for geo experiments: SUTVA violations, spillover, parallel-trends as the design check, and honest power calculations.">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Geo holdouts are not A/B tests",
+    "description": "Why the A/B framework fails for geo experiments: SUTVA violations, spillover, parallel-trends as the design check, and honest power calculations.",
+    "datePublished": "2025-08-15",
+    "author": {
+      "@type": "Person",
+      "name": "Inês Leite",
+      "url": "https://inesleite.github.io"
+    },
+    "publisher": {
+      "@type": "Person",
+      "name": "Inês Leite"
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://inesleite.github.io/posts/geo-holdouts-are-not-ab-tests.html"
+    }
+  }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/posts/llm-experiment-design.html
+++ b/posts/llm-experiment-design.html
@@ -4,6 +4,44 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Why I wouldn't trust an LLM to design my geo experiment — Inês Leite</title>
+  <meta name="description" content="A sceptical look at LLMs as experiment-design copilots: where they help (literature, code, drafting) and where they break (assumption auditing, real power, prior elicitation).">
+  <meta name="author" content="Inês Leite">
+  <link rel="canonical" href="https://inesleite.github.io/posts/llm-experiment-design.html">
+
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Why I wouldn't trust an LLM to design my geo experiment">
+  <meta property="og:description" content="A sceptical look at LLMs as experiment-design copilots: where they help (literature, code, drafting) and where they break (assumption auditing, real power, prior elicitation).">
+  <meta property="og:url" content="https://inesleite.github.io/posts/llm-experiment-design.html">
+  <meta property="og:site_name" content="Inês Leite">
+  <meta property="article:published_time" content="2026-05-05">
+  <meta property="article:author" content="Inês Leite">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Why I wouldn't trust an LLM to design my geo experiment">
+  <meta name="twitter:description" content="A sceptical look at LLMs as experiment-design copilots: where they help (literature, code, drafting) and where they break (assumption auditing, real power, prior elicitation).">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Why I wouldn't trust an LLM to design my geo experiment",
+    "description": "A sceptical look at LLMs as experiment-design copilots: where they help (literature, code, drafting) and where they break (assumption auditing, real power, prior elicitation).",
+    "datePublished": "2026-05-05",
+    "author": {
+      "@type": "Person",
+      "name": "Inês Leite",
+      "url": "https://inesleite.github.io"
+    },
+    "publisher": {
+      "@type": "Person",
+      "name": "Inês Leite"
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://inesleite.github.io/posts/llm-experiment-design.html"
+    }
+  }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/posts/synthetic-control-vs-geo-holdout.html
+++ b/posts/synthetic-control-vs-geo-holdout.html
@@ -4,6 +4,44 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Synthetic control vs geo holdout — Inês Leite</title>
+  <meta name="description" content="When to use synthetic control versus a prospective geo holdout: estimators, simplex weights, placebo inference, and what to do when they disagree.">
+  <meta name="author" content="Inês Leite">
+  <link rel="canonical" href="https://inesleite.github.io/posts/synthetic-control-vs-geo-holdout.html">
+
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Synthetic control vs geo holdout">
+  <meta property="og:description" content="When to use synthetic control versus a prospective geo holdout: estimators, simplex weights, placebo inference, and what to do when they disagree.">
+  <meta property="og:url" content="https://inesleite.github.io/posts/synthetic-control-vs-geo-holdout.html">
+  <meta property="og:site_name" content="Inês Leite">
+  <meta property="article:published_time" content="2026-03-15">
+  <meta property="article:author" content="Inês Leite">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Synthetic control vs geo holdout">
+  <meta name="twitter:description" content="When to use synthetic control versus a prospective geo holdout: estimators, simplex weights, placebo inference, and what to do when they disagree.">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Synthetic control vs geo holdout",
+    "description": "When to use synthetic control versus a prospective geo holdout: estimators, simplex weights, placebo inference, and what to do when they disagree.",
+    "datePublished": "2026-03-15",
+    "author": {
+      "@type": "Person",
+      "name": "Inês Leite",
+      "url": "https://inesleite.github.io"
+    },
+    "publisher": {
+      "@type": "Person",
+      "name": "Inês Leite"
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://inesleite.github.io/posts/synthetic-control-vs-geo-holdout.html"
+    }
+  }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/posts/time-window-randomisation.html
+++ b/posts/time-window-randomisation.html
@@ -4,6 +4,44 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Time-window randomisation: when you can't randomise the user — Inês Leite</title>
+  <meta name="description" content="Time-window randomisation for channels where user-level A/B isn't possible: alternating schedules, first-touch attribution, and the variance correction.">
+  <meta name="author" content="Inês Leite">
+  <link rel="canonical" href="https://inesleite.github.io/posts/time-window-randomisation.html">
+
+  <meta property="og:type" content="article">
+  <meta property="og:title" content="Time-window randomisation: when you can't randomise the user">
+  <meta property="og:description" content="Time-window randomisation for channels where user-level A/B isn't possible: alternating schedules, first-touch attribution, and the variance correction.">
+  <meta property="og:url" content="https://inesleite.github.io/posts/time-window-randomisation.html">
+  <meta property="og:site_name" content="Inês Leite">
+  <meta property="article:published_time" content="2026-05-04">
+  <meta property="article:author" content="Inês Leite">
+
+  <meta name="twitter:card" content="summary">
+  <meta name="twitter:title" content="Time-window randomisation: when you can't randomise the user">
+  <meta name="twitter:description" content="Time-window randomisation for channels where user-level A/B isn't possible: alternating schedules, first-touch attribution, and the variance correction.">
+
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    "headline": "Time-window randomisation: when you can't randomise the user",
+    "description": "Time-window randomisation for channels where user-level A/B isn't possible: alternating schedules, first-touch attribution, and the variance correction.",
+    "datePublished": "2026-05-04",
+    "author": {
+      "@type": "Person",
+      "name": "Inês Leite",
+      "url": "https://inesleite.github.io"
+    },
+    "publisher": {
+      "@type": "Person",
+      "name": "Inês Leite"
+    },
+    "mainEntityOfPage": {
+      "@type": "WebPage",
+      "@id": "https://inesleite.github.io/posts/time-window-randomisation.html"
+    }
+  }
+  </script>
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://inesleite.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <url>
+    <loc>https://inesleite.github.io/</loc>
+    <lastmod>2026-05-05</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+
+  <url>
+    <loc>https://inesleite.github.io/posts/llm-experiment-design.html</loc>
+    <lastmod>2026-05-05</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://inesleite.github.io/posts/time-window-randomisation.html</loc>
+    <lastmod>2026-05-04</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://inesleite.github.io/posts/synthetic-control-vs-geo-holdout.html</loc>
+    <lastmod>2026-03-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://inesleite.github.io/posts/calibrating-mmm-with-geo-experiments.html</loc>
+    <lastmod>2026-01-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+  <url>
+    <loc>https://inesleite.github.io/posts/geo-holdouts-are-not-ab-tests.html</loc>
+    <lastmod>2025-08-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+
+</urlset>


### PR DESCRIPTION
## Summary

Adds the technical SEO foundations the site was missing.

### Per-page metadata (all 5 posts + index)

- **`meta description`** — concise per-post summary, around 150 chars (the snippet Google shows under the link).
- **OpenGraph tags** — `og:type`, `og:title`, `og:description`, `og:url`, `og:site_name`, plus `article:published_time` and `article:author` on posts. Drives the preview card on LinkedIn / Slack / Discord / etc.
- **Twitter card** — `summary` type (no large-image variant since there are no per-post hero images yet).
- **`<link rel="canonical">`** — explicit canonical URL on each page.
- **JSON-LD `Article` schema** on each post and **`Person` schema** on the index, enabling Google rich results.

### Repo root

- **`sitemap.xml`** — index + 5 posts with `lastmod` dates and `priority`.
- **`robots.txt`** — allows all crawlers, points to the sitemap.

### What needs you, not me

- Verify ownership at **https://search.google.com/search-console** (DNS or meta-tag method) and submit `https://inesleite.github.io/sitemap.xml`. Until you do this, Google indexing relies on link-following alone and is much slower.
- Push the articles into channels that produce backlinks: **Hacker News**, **r/MachineLearning**, **LinkedIn**, cross-post on **Substack/Medium with `rel=canonical`** pointing back here. The technical fixes in this PR remove obstacles; backlinks are what actually move ranking.

### Test plan

- [ ] View source on each post and confirm the meta block renders cleanly.
- [ ] Drop a post URL into the LinkedIn or Twitter card validator and verify the preview is correct.
- [ ] Drop a post URL into Google's Rich Results Test (https://search.google.com/test/rich-results) and confirm the Article schema is recognised.
- [ ] After merge, fetch `https://inesleite.github.io/sitemap.xml` and `https://inesleite.github.io/robots.txt` and confirm both serve correctly.