### PR TITLE
Add Google Analytics gtag.js to all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,6 +478,14 @@
       .footer-inner { padding: 0 20px; flex-direction: column; gap: 8px; text-align: center; }
     }
   </style>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SXPVMRPCQ7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SXPVMRPCQ7');
+  </script>
 </head>
 <body>
 

--- a/posts/calibrating-mmm-with-geo-experiments.html
+++ b/posts/calibrating-mmm-with-geo-experiments.html
@@ -179,6 +179,14 @@
       font-family: 'JetBrains Mono', monospace;
     }
   </style>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SXPVMRPCQ7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SXPVMRPCQ7');
+  </script>
 </head>
 <body>
 

--- a/posts/geo-holdouts-are-not-ab-tests.html
+++ b/posts/geo-holdouts-are-not-ab-tests.html
@@ -192,6 +192,14 @@
       font-family: 'JetBrains Mono', monospace;
     }
   </style>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SXPVMRPCQ7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SXPVMRPCQ7');
+  </script>
 </head>
 <body>
 

--- a/posts/llm-experiment-design.html
+++ b/posts/llm-experiment-design.html
@@ -179,6 +179,14 @@
       font-family: 'JetBrains Mono', monospace;
     }
   </style>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SXPVMRPCQ7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SXPVMRPCQ7');
+  </script>
 </head>
 <body>
 

--- a/posts/synthetic-control-vs-geo-holdout.html
+++ b/posts/synthetic-control-vs-geo-holdout.html
@@ -196,6 +196,14 @@
       font-family: 'JetBrains Mono', monospace;
     }
   </style>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SXPVMRPCQ7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SXPVMRPCQ7');
+  </script>
 </head>
 <body>
 

--- a/posts/time-window-randomisation.html
+++ b/posts/time-window-randomisation.html
@@ -179,6 +179,14 @@
       font-family: 'JetBrains Mono', monospace;
     }
   </style>
+  <!-- Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-SXPVMRPCQ7"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-SXPVMRPCQ7');
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
Adds the Google Analytics gtag.js snippet (`G-SXPVMRPCQ7`) right before `</head>` on all 6 pages — index plus 5 posts. Async load, no consent banner per your instruction.

After this merges and Pages redeploys (~1-2 min), open the live site in an incognito window and check **Realtime** in https://analytics.google.com — you should see your own session.