### PR TITLE
Change site title to "Inês Leite Portfolio"

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,19 +3,19 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Inês Leite — Senior Data Scientist</title>
+  <title>Inês Leite Portfolio</title>
   <meta name="description" content="Senior Data Scientist specialising in causal inference, ML, and optimization. Based in Munich." />
   <meta name="author" content="Inês Leite" />
   <link rel="canonical" href="https://inesleite.github.io/" />
 
   <meta property="og:type" content="website" />
-  <meta property="og:title" content="Inês Leite — Senior Data Scientist" />
+  <meta property="og:title" content="Inês Leite Portfolio" />
   <meta property="og:description" content="Senior Data Scientist specialising in causal inference, ML, and optimization. Based in Munich. Writing on geo experiments, MMM calibration, and measurement." />
   <meta property="og:url" content="https://inesleite.github.io/" />
   <meta property="og:site_name" content="Inês Leite" />
 
   <meta name="twitter:card" content="summary" />
-  <meta name="twitter:title" content="Inês Leite — Senior Data Scientist" />
+  <meta name="twitter:title" content="Inês Leite Portfolio" />
   <meta name="twitter:description" content="Senior Data Scientist specialising in causal inference, ML, and optimization. Based in Munich." />
 
   <script type="application/ld+json">


### PR DESCRIPTION
## Summary
- Drops "Senior Data Scientist" from the site title.
- Updates `<title>`, `og:title`, and `twitter:title` on `index.html` to **Inês Leite Portfolio**.

The meta description, JSON-LD `jobTitle`, and the visible hero label on the homepage are intentionally left as-is — only the title strings change here.

## Test plan
- [ ] After merge, GitHub Pages deploy workflow runs and updates the `public` branch.
- [ ] Browser tab on https://inesleite.github.io/ shows "Inês Leite Portfolio".
- [ ] `view-source:` confirms `<title>`, `og:title`, `twitter:title` all updated.

https://claude.ai/code/session_01LXr4CLfPP6g75U8QYgpGvq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXr4CLfPP6g75U8QYgpGvq)_