### PR TITLE
Bump sitemap lastmod to 2026-05-12 to force GSC re-parse

### DIFF
--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,42 +3,42 @@
 
   <url>
     <loc>https://inesleite.github.io/</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
 
   <url>
     <loc>https://inesleite.github.io/posts/llm-experiment-design.html</loc>
-    <lastmod>2026-05-05</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://inesleite.github.io/posts/time-window-randomisation.html</loc>
-    <lastmod>2026-05-04</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://inesleite.github.io/posts/synthetic-control-vs-geo-holdout.html</loc>
-    <lastmod>2026-03-15</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://inesleite.github.io/posts/calibrating-mmm-with-geo-experiments.html</loc>
-    <lastmod>2026-01-15</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
 
   <url>
     <loc>https://inesleite.github.io/posts/geo-holdouts-are-not-ab-tests.html</loc>
-    <lastmod>2025-08-15</lastmod>
+    <lastmod>2026-05-12</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary
- Bumps all 6 `<lastmod>` dates in `sitemap.xml` to `2026-05-12` (today).
- Purpose: force Google to re-fetch and re-parse the sitemap so the cached "Sitemap could not be read" status in GSC clears.

## Test plan
- [ ] After merge, GitHub Pages deploy runs and serves the new `sitemap.xml`.
- [ ] In GSC → Sitemaps, re-submit `sitemap.xml` → status should flip to "Success" with 6 discovered pages.
- [ ] URL Inspection on the post URLs should now show "URL is on a referring sitemap" within hours.

https://claude.ai/code/session_01LXr4CLfPP6g75U8QYgpGvq

---
_Generated by [Claude Code](https://claude.ai/code/session_01LXr4CLfPP6g75U8QYgpGvq)_